### PR TITLE
fixed empty selects and add event listener for selects changing

### DIFF
--- a/src/addListeners.js
+++ b/src/addListeners.js
@@ -5,7 +5,7 @@ var validate = require('./validate');
 var getErrorElement = require('./helpers/getErrorElement');
 
 // Handle elements with data-validations properties
-$(document).on('keyup click change blur', 'input, textarea', function (e) {
+$(document).on('keyup click change blur', 'input, textarea, select', function (e) {
   var $this = $(this);
 
   // If an input has no validators, assume that it is always valid

--- a/src/validate.js
+++ b/src/validate.js
@@ -24,7 +24,7 @@ validate.element = function validateElement(input, setClasses) {
 
   if (!$input.hasClass('is-filled')) {
     // 0 < undefined
-    if ($input.val().length < $input.data('validate-at')) {
+    if ($input.val() && $input.val().length < $input.data('validate-at')) {
       return;
     }
 


### PR DESCRIPTION
Empty selects were throwing an error as val() came back as null, not an empty string - this is now fixed.

Selects are now included in the event listener for changes.
