### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lmn.tarantula": "0.5.x"
   },
   "devDependencies": {
+    "babelify": "^6.3.0",
     "browser-sync": "^2.9.10",
     "gulp": "^3.8.10",
     "lmn-gulp-tasks": "^3.0.1",

--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -22,10 +22,6 @@ validate.element = function validateElement(input, setClasses) {
   var $input = $(input);
   var validations;
 
-  if (!$input.data('validations')) {
-    return;
-  }
-
   if (!$input.hasClass('is-filled')) {
     // 0 < undefined
     if ($input.val() && $input.val().length < $input.data('validate-at')) {


### PR DESCRIPTION
The babelify dependency is need at the very least to make validation work when `npm link`ing
After @mrcthms identified our rollbar error in https://github.com/Lostmyname/validation/pull/10 I found I could just pull out the check.
