### PR TITLE
Bug Fix, Validation being applied to all forms regardless of if they have validated elements

### DIFF
--- a/src/js/addListeners.js
+++ b/src/js/addListeners.js
@@ -47,7 +47,7 @@ function onChange(e) {
 // Remove required attributes, and disable submits
 $(document).ready(function () {
   $('form')
-    .filter(() => $(this).find('[data-validations]').length)
+    .filter((_, el) => $(el).find('[data-validations]').length)
     .each(function () {
       var $this = $(this);
 


### PR DESCRIPTION
Issue: All forms are being registered to use validation even if the form has no validated elements. One side effect of this is disabled buttons being re-enabled.

Fix: corrects filter to use the scope. 
